### PR TITLE
Update to latest faraday, remove deprecated faraday_middleware gem

### DIFF
--- a/abuseipdb-rb.gemspec
+++ b/abuseipdb-rb.gemspec
@@ -37,6 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr", '~> 4.0', '>= 4.0.0'
 
-  spec.add_runtime_dependency 'faraday', '~> 1.0', '>= 0.15.2'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 1.0', '>= 0.12.2'
+  spec.add_runtime_dependency 'faraday', '~> 2.0'
 end

--- a/lib/abuseipdb/client.rb
+++ b/lib/abuseipdb/client.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'faraday_middleware'
 
 require 'abuseipdb/configuration'
 require 'abuseipdb/endpoints/base'


### PR DESCRIPTION
Faraday is now on 2.x, also faraday_middleware is deprecated.